### PR TITLE
Better Stream is offline handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,19 @@ justinfan with a string of up to 5 numbers and no password creates an anonomous 
 
     "slack_token": "SOME-SOME-KEY",
 
-    "sendstreamertogeneral": true
+    "sendstreamertogeneral": true,
+    "offline_toggle": 5
 }
 ```
+
+  - irc - holds ALL Irc connection settings
+    - network - usually irc.twitch.tv
+    - userName - justinfan12345 is an anon login, no password needed
+    - password
+      - usually oauth:SOMESTRING
+      - connecting a Application to a known user with the chat scope parameter
+      - blank when Justinfan-ing
+  - twitch_client_id - obtained from [Twitch Connections](http://www.twitch.tv/settings/connections)
+  - slack_token - you are given this at Bot Creation in Slack Integrations
+  - sendstreamertogeneral - send online/offline updates to #general
+  - offline_toggle - number of minutes to wait before saying channel is offline 3-5 recommended

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "irc": "^0.3.7",
+    "node-crontab": "0.0.8",
     "request": "^2.58.0",
     "slack-client": "^1.4.0"
   }

--- a/tb.js
+++ b/tb.js
@@ -2,6 +2,7 @@ var Slack = require('slack-client');
 var request = require('request');
 var irc = require('irc');
 var fs = require('fs');
+var crontab = require('node-crontab');
 
 var config = JSON.parse(fs.readFileSync(__dirname + '/config.json', 'utf8'));
 
@@ -52,14 +53,6 @@ function init() {
         metadata[item] = {}
         metadata[item]['statechange'] = Date.now()
         metadata[item]['state'] = false
-    })
-    setInterval(streamer_statuspoll, 10000);
-}
-
-function streamer_statuspoll() {
-//    console.log('polling');
-    streamers.forEach(function(item) {
-        streamer_poll(item)
     })
 }
 
@@ -197,6 +190,12 @@ slack.on('message', function(message) {
     }
 });
 
+/* Cron */
+var jobId = crontab.scheduleJob("* * * * *", function() {
+    streamers.forEach(function(item) {
+        streamer_poll(item)
+    })
+});
 
 /* utility functions */
 var convertTime = function(date_future, date_now) {


### PR DESCRIPTION
Switch to Cron for polling for streamer updates.
As per Twitch API Specs poll once per minute

Only announce stream offline if offline for configured minutes 3-5 works best I find.
